### PR TITLE
Remove old stages from `dvc.lock`

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -1,25 +1,3 @@
+---
 schema: '2.0'
-stages:
-  iris_sqlite:
-    cmd: Rscript R/build_iris_sqlite.R
-    outs:
-    - path: data/iris.sqlite
-      md5: 919a165fe605e7084168aafe3542c099
-      size: 16384
-  mtcars:
-    cmd: Rscript R/mtcars.R
-    deps:
-    - path: R/mtcars.R
-      md5: 7a80d0296493b05d4d84cc12ec94e20f
-      size: 124
-    outs:
-    - path: data/mtcars.parquet
-      md5: cc1ba147effafe2e0aa844f598a7c30d
-      size: 6234
-  nested_tbls:
-    cmd: Rscript R/build_nested_namespace.R
-    outs:
-    - path: data/rtbls/
-      md5: a0038a50e44a720cd151365e5877bf48.dir
-      size: 10263
-      nfiles: 2
+stages: {}


### PR DESCRIPTION
Many bricks have old stages from the brick-template.
